### PR TITLE
Seidr-29 Pin Werkzeug and Flask-AppBuilder Version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,9 @@ url = https://github.com/dttctcs/seidr
 [options]
 packages = find:
 install_requires =
-    Flask-AppBuilder
+    Flask-AppBuilder<=4.3.9
     Flask-Migrate
-    marshmallow-enum
+    Werkzeug<3.0.0
     
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Pinned Werkzeug Version to Fix #29 and pinned Flask-AppBuilder to < 4.3.9. As soon as Flask migrates to Werkzeug we can remove these pinsa gain